### PR TITLE
CMakeLists: fixed detection of OpenMP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # minimum version is 3.0 to be able to handle Eigen library
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 3.12)
 project (FasterCap)
 
 # main project specific settings
@@ -31,12 +31,17 @@ endif()
 # so that code knows whether it needs to #include config.h
 #add_definitions(-DHAVE_CONFIG_H)
 #
-# List of options to pass to the compiler (note this is a CMake list. Do not enclose in ")
-set(FASTFIELDSOLVERS_COMPILE_OPTIONS ${FASTFIELDSOLVERS_COMPILE_OPTIONS} -Wextra -Wall -fopenmp)
-# -fopenmp: use OpenMP pragmas
-# -lm: link the math library
-# -lstdc++: link the standard c++ library (needed for headless)
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fopenmp -lm -lstdc++")
+
+find_package(OpenMP)
+if(OpenMP_CXX_FOUND)
+    set (EXTRA_LIBS ${EXTRA_LIBS} OpenMP::OpenMP_CXX)
+else()
+    message(FATAL_ERROR "Unable to find OpenMP. Try exporting the OpenMP_ROOT environmental variable. E.g., on macOS: export OpenMP_ROOT=$(brew --prefix)/opt/libomp")
+endif()
+
+
+set(FASTFIELDSOLVERS_COMPILE_OPTIONS ${FASTFIELDSOLVERS_COMPILE_OPTIONS} -Wextra -Wall)
+
 # -s: strip all symbols from the executable
 set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} -s")
 
@@ -123,6 +128,9 @@ if(${FASTFIELDSOLVERS_HEADLESS} MATCHES OFF)
 endif()
 
 add_executable (FasterCap ${FastFieldSolvers_Sources} ${FasterCap_Sources})
+
+set (EXTRA_LIBS ${EXTRA_LIBS}  -lm -lstdc++)
+
 # Specify compile options to use when compiling a given target.
 target_compile_options(FasterCap PUBLIC ${FASTFIELDSOLVERS_COMPILE_OPTIONS})
 target_link_libraries(FasterCap ${EXTRA_LIBS} ${WXWIDGETS_LIBS} ${EIGEN_LIBS})

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The following software tools and complier chains are required. Used versions are
 
 ###  MS Windows 64 bits
 
-- CMake 3.6.0
+- CMake 3.12
 - Code::Blocks, version 13.12
 - TDM-GCC 64 bits, version 4.8.1
 - wxWidgets, version 3.0
@@ -36,7 +36,7 @@ The following software tools and complier chains are required. Used versions are
 
 ###  Linux 64 bits
 
-- CMake 2.8.12
+- CMake 3.12
 - Code::Blocks, version 13.12
 - GCC, version 4.8.1
 - wxWidgets (wxGTK), version 3.0
@@ -55,7 +55,7 @@ Then you can open Code::Blocks, open the FasterCap.cbp project file created by C
 
 ###  Linux 64 bits headless
 
-- CMake 3.5.1
+- CMake 3.12
 - GCC, version 4.8.1 or higher (higher version tested: on 5.4.0)
 - wxWidgets, version 3.0.2 or higher (higher version tested: 3.0.2)
 


### PR DESCRIPTION
Requires newer CMake version.
This now also works with clang compiler (e.g. on macOS).